### PR TITLE
Removed hardcoded warmup steps. 

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1876,8 +1876,8 @@ class Trainer:
 
         metrics = speed_metrics("train", start_time, num_samples=num_train_samples, num_steps=self.state.max_steps)
 
-        total_samples = args.max_steps*total_train_batch_size if args.max_steps > 0  else num_examples*num_train_epochs
-        perf_samples = total_samples - 10*total_train_batch_size
+        total_samples = self.state.global_step*total_train_batch_size if args.max_steps > 0 else num_examples*num_train_epochs
+        perf_samples = total_samples - self.args.warmup_steps*total_train_batch_size
         stable_train_metrics = speed_metrics("stable_train", start_train_stable_time, perf_samples)
 
         self.store_flos()

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -568,7 +568,7 @@ class TrainingArguments:
     warmup_ratio: float = field(
         default=0.0, metadata={"help": "Linear warmup over warmup_ratio fraction of total steps."}
     )
-    warmup_steps: int = field(default=0, metadata={"help": "Linear warmup over warmup_steps."})
+    warmup_steps: int = field(default=10, metadata={"help": "Linear warmup over warmup_steps."})
 
     log_level: Optional[str] = field(
         default="passive",


### PR DESCRIPTION
This PR is in regards to the following issue: https://github.com/ROCmSoftwarePlatform/DeepLearningModels/issues/400

The PR removes previously hardcoded warmup steps and replaces the max_steps in training with global steps for accurate representation.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/adabeyta/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/adabeyta/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{mso-header-data:"&L&\0022Arial\0022&10&K0000FF \[AMD Official Use Only - General\]&1\#\000D";
	margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{border:.5pt solid windowtext;}
.xl64
	{text-align:center;
	border:.5pt solid windowtext;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



model | Performance   After Change | Performance   Before Change
-- | -- | --
pyt_huggingface_pegasus | 13.728 | 13.443
pyt_huggingface_distilbart_cnn | 26.02 | 25.484
pyt_huggingface_bert | 33.545 | 33.711
pyt_huggingface_bart | 94.759 | 94.994
pyt_huggingface_distilbert-base | 136.229 | 132.002
pyt_huggingface_t5-large | 53.276 | 51.1
pyt_huggingface_deberta-v2-xxlarge | 64.05 | 64.089
pyt_huggingface_gpt_neo | 10.943 | 11.394
pyt_huggingface_gpt2 | 26.245 | 26.232
pyt_huggingface_roberta-large | 49.332 | 49.284



</body>

</html>

