### PR TITLE
Add tf-nightly-rocm to _is_tf_available check

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -73,6 +73,7 @@ else:
                 "tf-nightly",
                 "tf-nightly-cpu",
                 "tf-nightly-gpu",
+                "tf-nightly-rocm",
                 "intel-tensorflow",
                 "intel-tensorflow-avx512",
                 "tensorflow-rocm",


### PR DESCRIPTION
# What does this PR do?

This PR adds tf-nightly-rocm to the list of packages to check to ensure tensorflow is installed. We've recently started building tf-nightly-rocm packages and this check fails. 
Add `tf-nightly-rocm` to the _is_tf_available() check 